### PR TITLE
Add sub menu toggle and parent menu selector

### DIFF
--- a/js/components/admin-page-settings.js
+++ b/js/components/admin-page-settings.js
@@ -9,9 +9,7 @@ const { withSelect, withDispatch } = wp.data;
 
 const icon = 'editor-ul';
 
-import MetaTextControl from './meta-text-control';
-import MetaSelectControl from './meta-select-control';
-import MetaToggleControl from './meta-toggle-control';
+import { MetaTextControl, MetaSelectControl, MetaToggleControl } from '.';
 
 const AdminPageSettings = function( props ) {
 	return (
@@ -34,12 +32,15 @@ const AdminPageSettings = function( props ) {
 				/>
 			</PanelRow>
 			{ props.postMeta.sub_menu &&
-				<PanelRow>
-					<MetaSelectControl
-						label={ __( 'Menu Parent', 'hello-admin' ) }
-						metaKey="menu_parent"
-					/>
-				</PanelRow>
+				<>
+					<PanelRow>
+						<MetaSelectControl
+							label={ __( 'Menu Parent', 'hello-admin' ) }
+							metaKey="parent_menu"
+							placeholder={ __( 'Select Parent Menu', 'hello-admin' ) }
+						/>
+					</PanelRow>
+				</>
 			}
 		</PluginDocumentSettingPanel>
 	);

--- a/js/components/admin-page-settings.js
+++ b/js/components/admin-page-settings.js
@@ -4,14 +4,53 @@
 const { __ } = wp.i18n;
 const { PluginDocumentSettingPanel } = wp.editPost;
 const { PanelRow } = wp.components;
-const { compose } = wp.compose;
-const { withSelect, withDispatch } = wp.data;
+const { useSelect } = wp.data;
+const { useState } = wp.element;
+const apiFetch = wp.apiFetch;
 
 const icon = 'editor-ul';
 
 import { MetaTextControl, MetaSelectControl, MetaToggleControl } from '.';
 
-const AdminPageSettings = function( props ) {
+const AdminPageSettings = function() {
+	const { postMeta } = useSelect( ( select ) => {
+		return {
+			postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+		};
+	} );
+
+	const [ state, setState ] = useState( {
+		loading: true,
+		menuItems: [
+			{ value: -1, label: __( 'Select Parent Menu', 'hello-admin' ) },
+			{ value: -1, label: __( 'Loading…', 'hello-admin' ), disabled: true },
+		],
+	} );
+
+	if ( state.loading ) {
+		apiFetch( { path: '/hello-admin/v1/menus' } ).then( ( { success, data } ) => {
+			if ( success ) {
+				const menuItems = [ state.menuItems[ 0 ] ];
+				for ( const id in data ) {
+					let label = data[ id ][ 0 ];
+
+					if ( '' === label ) {
+						continue;
+					}
+
+					// Remove HTML from label.
+					label = label.replace( /<\w+(?: \w*=".*")*>.*<\/\w+>/g, '' ).trim();
+
+					menuItems.push( { value: id, label } );
+				}
+				setState( {
+					loading: false,
+					menuItems,
+				} );
+			}
+		} );
+	}
+
 	return (
 		<PluginDocumentSettingPanel
 			name="hello-admin-menu-panel"
@@ -31,13 +70,13 @@ const AdminPageSettings = function( props ) {
 					metaKey="sub_menu"
 				/>
 			</PanelRow>
-			{ props.postMeta.sub_menu &&
+			{ postMeta.sub_menu &&
 				<>
 					<PanelRow>
 						<MetaSelectControl
+							options={ state.menuItems }
 							label={ __( 'Menu Parent', 'hello-admin' ) }
 							metaKey="parent_menu"
-							placeholder={ __( 'Select Parent Menu', 'hello-admin' ) }
 						/>
 					</PanelRow>
 				</>
@@ -46,18 +85,4 @@ const AdminPageSettings = function( props ) {
 	);
 };
 
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
-			postType: select( 'core/editor' ).getCurrentPostType(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		return {
-			setPostMeta( newMeta ) {
-				dispatch( 'core/editor' ).editPost( { meta: newMeta } );
-			},
-		};
-	} ),
-] )( AdminPageSettings );
+export default AdminPageSettings;

--- a/js/components/admin-page-settings.js
+++ b/js/components/admin-page-settings.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies.
+ */
+const { __ } = wp.i18n;
+const { PluginDocumentSettingPanel } = wp.editPost;
+const { PanelRow } = wp.components;
+const { compose } = wp.compose;
+const { withSelect, withDispatch } = wp.data;
+
+const icon = 'editor-ul';
+
+import MetaTextControl from './meta-text-control';
+import MetaSelectControl from './meta-select-control';
+import MetaToggleControl from './meta-toggle-control';
+
+const AdminPageSettings = function( props ) {
+	return (
+		<PluginDocumentSettingPanel
+			name="hello-admin-menu-panel"
+			title={ __( 'Admin Menu' ) }
+			icon={ icon }
+		>
+			<PanelRow>
+				<MetaTextControl
+					type="number"
+					label={ __( 'Menu Position', 'hello-admin' ) }
+					metaKey="menu_position"
+				/>
+			</PanelRow>
+			<PanelRow>
+				<MetaToggleControl
+					label={ __( 'Sub-Menu', 'hello-admin' ) }
+					metaKey="sub_menu"
+				/>
+			</PanelRow>
+			{ props.postMeta.sub_menu &&
+				<PanelRow>
+					<MetaSelectControl
+						label={ __( 'Menu Parent', 'hello-admin' ) }
+						metaKey="menu_parent"
+					/>
+				</PanelRow>
+			}
+		</PluginDocumentSettingPanel>
+	);
+};
+
+export default compose( [
+	withSelect( ( select ) => {
+		return {
+			postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+			postType: select( 'core/editor' ).getCurrentPostType(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		return {
+			setPostMeta( newMeta ) {
+				dispatch( 'core/editor' ).editPost( { meta: newMeta } );
+			},
+		};
+	} ),
+] )( AdminPageSettings );

--- a/js/components/index.js
+++ b/js/components/index.js
@@ -1,0 +1,3 @@
+export { default as MetaTextControl } from './meta-text-control';
+export { default as MetaSelectControl } from './meta-select-control';
+export { default as MetaToggleControl } from './meta-toggle-control';

--- a/js/components/meta-select-control.js
+++ b/js/components/meta-select-control.js
@@ -5,6 +5,7 @@ const { __ } = wp.i18n;
 const { SelectControl } = wp.components;
 const { withSelect, withDispatch } = wp.data;
 const { compose } = wp.compose;
+const apiFetch = wp.apiFetch;
 
 const MetaSelectControl = compose(
 	withDispatch( function( dispatch, props ) {
@@ -24,24 +25,32 @@ const MetaSelectControl = compose(
 			metaKey: 'sub_menu',
 			metaValue: 0,
 		};
+
+		let primaryMenus;
+		apiFetch( { path: '/hello-admin/v1/menus' } ).then( ( menus ) => {
+			primaryMenus = menus;
+		} );
+
 		return {
 			metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
 			adminPages: select( 'core' ).getEntityRecords( 'postType', 'admin-page', query ),
+			allPages: primaryMenus,
 		};
 	} )
 )( function( props ) {
-	const choices = [];
+	const options = [
+		{ value: -1, label: props.placeholder },
+	];
 	if ( props.adminPages ) {
-		choices.push( { value: 0, label: __( 'Select Parent Menu', 'hello-admin' ) } );
 		props.adminPages.forEach( ( post ) => {
-			choices.push( { value: post.id, label: post.title.rendered } );
+			options.push( { value: post.id, label: post.title.rendered } );
 		} );
 	} else {
-		choices.push( { value: 0, label: __( 'Loading', 'hello-admin' ) } );
+		options.push( { value: -1, label: __( 'Loading…', 'hello-admin' ), disabled: true } );
 	}
 	return (
 		<SelectControl
-			options={ choices }
+			options={ options }
 			label={ props.label }
 			value={ props.metaValue }
 			onChange={ ( value ) => {

--- a/js/components/meta-select-control.js
+++ b/js/components/meta-select-control.js
@@ -1,61 +1,24 @@
 /**
  * WordPress dependencies.
  */
-const { __ } = wp.i18n;
 const { SelectControl } = wp.components;
-const { withSelect, withDispatch } = wp.data;
-const { compose } = wp.compose;
-const apiFetch = wp.apiFetch;
+const { useSelect, useDispatch } = wp.data;
 
-const MetaSelectControl = compose(
-	withDispatch( function( dispatch, props ) {
+const MetaSelectControl = ( function( props ) {
+	const { postMeta } = useSelect( ( select ) => {
 		return {
-			setMetaValue( value ) {
-				dispatch( 'core/editor' ).editPost( {
-					meta: { [ props.metaKey ]: value },
-				} );
-			},
+			postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
 		};
-	} ),
-	withSelect( function( select, props ) {
-		const currentPostId = select( 'core/editor' ).getCurrentPostId();
-		const query = {
-			per_page: -1,
-			exclude: currentPostId,
-			metaKey: 'sub_menu',
-			metaValue: 0,
-		};
+	} );
 
-		let primaryMenus;
-		apiFetch( { path: '/hello-admin/v1/menus' } ).then( ( menus ) => {
-			primaryMenus = menus;
-		} );
+	const { editPost } = useDispatch( 'core/editor', [ props.metaKey ] );
 
-		return {
-			metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
-			adminPages: select( 'core' ).getEntityRecords( 'postType', 'admin-page', query ),
-			allPages: primaryMenus,
-		};
-	} )
-)( function( props ) {
-	const options = [
-		{ value: -1, label: props.placeholder },
-	];
-	if ( props.adminPages ) {
-		props.adminPages.forEach( ( post ) => {
-			options.push( { value: post.id, label: post.title.rendered } );
-		} );
-	} else {
-		options.push( { value: -1, label: __( 'Loading…', 'hello-admin' ), disabled: true } );
-	}
 	return (
 		<SelectControl
-			options={ options }
+			options={ props.options }
 			label={ props.label }
-			value={ props.metaValue }
-			onChange={ ( value ) => {
-				props.setMetaValue( value );
-			} }
+			value={ postMeta[ props.metaKey ] }
+			onChange={ ( value ) => editPost( { meta: { [ props.metaKey ]: value } } ) }
 		/>
 	);
 } );

--- a/js/components/meta-select-control.js
+++ b/js/components/meta-select-control.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies.
+ */
+const { __ } = wp.i18n;
+const { SelectControl } = wp.components;
+const { withSelect, withDispatch } = wp.data;
+const { compose } = wp.compose;
+
+const MetaSelectControl = compose(
+	withDispatch( function( dispatch, props ) {
+		return {
+			setMetaValue( value ) {
+				dispatch( 'core/editor' ).editPost( {
+					meta: { [ props.metaKey ]: value },
+				} );
+			},
+		};
+	} ),
+	withSelect( function( select, props ) {
+		const currentPostId = select( 'core/editor' ).getCurrentPostId();
+		const query = {
+			per_page: -1,
+			exclude: currentPostId,
+			metaKey: 'sub_menu',
+			metaValue: 0,
+		};
+		return {
+			metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
+			adminPages: select( 'core' ).getEntityRecords( 'postType', 'admin-page', query ),
+		};
+	} )
+)( function( props ) {
+	const choices = [];
+	if ( props.adminPages ) {
+		choices.push( { value: 0, label: __( 'Select Parent Menu', 'hello-admin' ) } );
+		props.adminPages.forEach( ( post ) => {
+			choices.push( { value: post.id, label: post.title.rendered } );
+		} );
+	} else {
+		choices.push( { value: 0, label: __( 'Loading', 'hello-admin' ) } );
+	}
+	return (
+		<SelectControl
+			options={ choices }
+			label={ props.label }
+			value={ props.metaValue }
+			onChange={ ( value ) => {
+				props.setMetaValue( value );
+			} }
+		/>
+	);
+} );
+
+export default MetaSelectControl;

--- a/js/components/meta-text-control.js
+++ b/js/components/meta-text-control.js
@@ -2,33 +2,23 @@
  * WordPress dependencies.
  */
 const { TextControl } = wp.components;
-const { withSelect, withDispatch } = wp.data;
-const { compose } = wp.compose;
+const { useSelect, useDispatch } = wp.data;
 
-const MetaTextControl = compose(
-	withDispatch( function( dispatch, props ) {
+const MetaTextControl = ( function( props ) {
+	const { postMeta } = useSelect( ( select ) => {
 		return {
-			setMetaValue( value ) {
-				dispatch( 'core/editor' ).editPost( {
-					meta: { [ props.metaKey ]: value },
-				} );
-			},
+			postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
 		};
-	} ),
-	withSelect( function( select, props ) {
-		return {
-			metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
-		};
-	} )
-)( function( props ) {
+	} );
+
+	const { editPost } = useDispatch( 'core/editor', [ props.metaKey ] );
+
 	return (
 		<TextControl
 			type={ props.type }
 			label={ props.label }
-			value={ props.metaValue }
-			onChange={ ( value ) => {
-				props.setMetaValue( value );
-			} }
+			value={ postMeta[ props.metaKey ] }
+			onChange={ ( value ) => editPost( { meta: { [ props.metaKey ]: value } } ) }
 		/>
 	);
 } );

--- a/js/components/meta-text-control.js
+++ b/js/components/meta-text-control.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies.
+ */
+const { TextControl } = wp.components;
+const { withSelect, withDispatch } = wp.data;
+const { compose } = wp.compose;
+
+const MetaTextControl = compose(
+	withDispatch( function( dispatch, props ) {
+		return {
+			setMetaValue( value ) {
+				dispatch( 'core/editor' ).editPost( {
+					meta: { [ props.metaKey ]: value },
+				} );
+			},
+		};
+	} ),
+	withSelect( function( select, props ) {
+		return {
+			metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
+		};
+	} )
+)( function( props ) {
+	return (
+		<TextControl
+			type={ props.type }
+			label={ props.label }
+			value={ props.metaValue }
+			onChange={ ( value ) => {
+				props.setMetaValue( value );
+			} }
+		/>
+	);
+} );
+
+export default MetaTextControl;

--- a/js/components/meta-toggle-control.js
+++ b/js/components/meta-toggle-control.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies.
+ */
+const { ToggleControl } = wp.components;
+const { withSelect, withDispatch } = wp.data;
+const { compose } = wp.compose;
+
+const MetaToggleControl = compose(
+	withDispatch( function( dispatch, props ) {
+		return {
+			setMetaValue( value ) {
+				dispatch( 'core/editor' ).editPost( {
+					meta: { [ props.metaKey ]: value },
+				} );
+			},
+		};
+	} ),
+	withSelect( function( select, props ) {
+		return {
+			metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
+		};
+	} )
+)( function( props ) {
+	return (
+		<ToggleControl
+			label={ props.label }
+			checked={ props.metaValue }
+			onChange={ ( value ) => {
+				props.setMetaValue( value );
+			} }
+		/>
+	);
+} );
+
+export default MetaToggleControl;

--- a/js/components/meta-toggle-control.js
+++ b/js/components/meta-toggle-control.js
@@ -2,32 +2,21 @@
  * WordPress dependencies.
  */
 const { ToggleControl } = wp.components;
-const { withSelect, withDispatch } = wp.data;
-const { compose } = wp.compose;
+const { useSelect, useDispatch } = wp.data;
 
-const MetaToggleControl = compose(
-	withDispatch( function( dispatch, props ) {
+const MetaToggleControl = ( function( props ) {
+	const { postMeta } = useSelect( ( select ) => {
 		return {
-			setMetaValue( value ) {
-				dispatch( 'core/editor' ).editPost( {
-					meta: { [ props.metaKey ]: value },
-				} );
-			},
+			postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
 		};
-	} ),
-	withSelect( function( select, props ) {
-		return {
-			metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
-		};
-	} )
-)( function( props ) {
+	} );
+
+	const { editPost } = useDispatch( 'core/editor', [ props.metaKey ] );
 	return (
 		<ToggleControl
 			label={ props.label }
-			checked={ props.metaValue }
-			onChange={ ( value ) => {
-				props.setMetaValue( value );
-			} }
+			checked={ postMeta[ props.metaKey ] }
+			onChange={ ( value ) => editPost( { meta: { [ props.metaKey ]: value } } ) }
 		/>
 	);
 } );

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -1,60 +1,12 @@
 /**
  * WordPress dependencies.
  */
+const { registerPlugin } = wp.plugins;
 
-( function( wp ) {
-	const { __ } = wp.i18n;
-	const { registerPlugin } = wp.plugins;
-	const { PluginDocumentSettingPanel } = wp.editPost;
-	const { TextControl } = wp.components;
-	const { withSelect, withDispatch } = wp.data;
-	const { compose } = wp.compose;
+import AdminPageSettings from './components/admin-page-settings';
 
-	const icon = 'editor-ul';
-
-	const MetaTextControl = compose(
-		withDispatch( function( dispatch, props ) {
-			return {
-				setMetaValue( value ) {
-					dispatch( 'core/editor' ).editPost( {
-						meta: { [ props.metaKey ]: value },
-					} );
-				},
-			};
-		} ),
-		withSelect( function( select, props ) {
-			return {
-				metaValue: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ props.metaKey ],
-			};
-		} )
-	)( function( props ) {
-		return (
-			<TextControl
-				type={ props.type }
-				label={ props.label }
-				value={ props.metaValue }
-				onChange={ ( value ) => {
-					props.setMetaValue( value );
-				} }
-			/>
-		);
-	} );
-
-	registerPlugin( 'hello-admin-menu-panel', {
-		render() {
-			return (
-				<PluginDocumentSettingPanel
-					name="hello-admin-menu-panel"
-					title={ __( 'Admin Menu' ) }
-					icon={ icon }
-				>
-					<MetaTextControl
-						type="number"
-						label={ __( 'Menu Position', 'hello-admin' ) }
-						metaKey="menu_position"
-					/>
-				</PluginDocumentSettingPanel>
-			);
-		},
-	} );
-}( window.wp ) );
+registerPlugin( 'hello-admin-menu-panel', {
+	render() {
+		return <AdminPageSettings />;
+	},
+} );

--- a/php/class-admin-menu.php
+++ b/php/class-admin-menu.php
@@ -19,6 +19,13 @@ class Admin_Menu {
 	public $prefix = 'admin-page-';
 
 	/**
+	 * The option key used to save all menu items into a transient.
+	 *
+	 * @var string
+	 */
+	const MENU_OPTION_KEY = 'hello-admin-all-menu-items';
+
+	/**
 	 * Plugin constructor.
 	 */
 	public function __construct() {
@@ -33,6 +40,7 @@ class Admin_Menu {
 	public function register_hooks() {
 		add_action( 'admin_menu', [ $this, 'register_menu_items' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		add_action( 'admin_menu', [ $this, 'save_all_menu_items' ], 99 );
 	}
 
 	/**
@@ -106,6 +114,11 @@ class Admin_Menu {
 		}
 
 		wp_reset_postdata();
+	}
+
+	public function save_all_menu_items() {
+		global $menu;
+		set_transient( self::MENU_OPTION_KEY, $menu );
 	}
 
 	/**

--- a/php/class-admin-menu.php
+++ b/php/class-admin-menu.php
@@ -51,7 +51,7 @@ class Admin_Menu {
 
 		while ( $admin_pages_query->have_posts() ) {
 			$admin_pages_query->the_post();
-			$menu_position = get_post_meta(
+			$menu_position = (int) get_post_meta(
 				get_the_ID(),
 				hello_admin()->post_type->menu_position_key,
 				true
@@ -96,7 +96,6 @@ class Admin_Menu {
 					'read',
 					$menu_slug,
 					[ $this, 'render_menu_page' ],
-					'',
 					$menu_position
 				);
 			}

--- a/php/class-admin-menu.php
+++ b/php/class-admin-menu.php
@@ -47,6 +47,8 @@ class Admin_Menu {
 	 * Register the custom post type.
 	 */
 	public function register_menu_items() {
+		global $menu;
+
 		$admin_pages_query = new \WP_Query(
 			[
 				'posts_per_page' => 99,
@@ -85,7 +87,7 @@ class Admin_Menu {
 					true
 				);
 
-				$parent_slug = $this->prefix . get_post_field( 'post_name', $parent_menu );
+				$parent_slug = $menu[ $parent_menu ][2];
 
 				if ( $menu_position < 1 ) {
 					$menu_position = 1;
@@ -116,6 +118,9 @@ class Admin_Menu {
 		wp_reset_postdata();
 	}
 
+	/**
+	 * Add global $menu variable to transient.
+	 */
 	public function save_all_menu_items() {
 		global $menu;
 		set_transient( self::MENU_OPTION_KEY, $menu );

--- a/php/class-admin-menu.php
+++ b/php/class-admin-menu.php
@@ -70,24 +70,18 @@ class Admin_Menu {
 			$title     = get_the_title();
 			$menu_slug = $this->prefix . get_post_field( 'post_name' );
 
-			if ( ! $sub_menu ) {
-				add_menu_page(
-					$title,
-					$title,
-					'read',
-					$menu_slug,
-					[ $this, 'render_menu_page' ],
-					'',
-					$menu_position
-				);
-			} else {
-				$menu_parent = get_post_meta(
+			if ( $sub_menu ) {
+				$parent_menu = get_post_meta(
 					get_the_ID(),
-					hello_admin()->post_type->menu_parent_key,
+					hello_admin()->post_type->parent_menu_key,
 					true
 				);
 
-				$parent_slug = $this->prefix . get_post_field( 'post_name', $menu_parent );
+				$parent_slug = $this->prefix . get_post_field( 'post_name', $parent_menu );
+
+				if ( $menu_position < 1 ) {
+					$menu_position = 1;
+				}
 
 				add_submenu_page(
 					$parent_slug,
@@ -96,6 +90,16 @@ class Admin_Menu {
 					'read',
 					$menu_slug,
 					[ $this, 'render_menu_page' ],
+					$menu_position
+				);
+			} else {
+				add_menu_page(
+					$title,
+					$title,
+					'read',
+					$menu_slug,
+					[ $this, 'render_menu_page' ],
+					'',
 					$menu_position
 				);
 			}

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -60,7 +60,6 @@ class Post_Type {
 		add_action( 'admin_init', [ $this, 'dequeue_block_styles' ], 99 );
 		add_action( 'admin_init', [ $this, 'dequeue_editor_styles' ], 99 );
 		add_action( 'admin_init', [ $this, 'add_editor_color_palette' ], 100 );
-		add_action( 'save_post', [ $this, 'add_default_sub_menu_meta_to_post' ], 10, 2 );
 		add_filter( 'rest_admin-page_query', [ $this, 'admin_page_sub_menu_query' ], 10, 2 );
 		add_action( 'rest_api_init', [ $this, 'register_custom_routes' ], 999 );
 	}
@@ -149,7 +148,6 @@ class Post_Type {
 			'parent_menu',
 			[
 				'object_subtype' => $this->slug,
-				'type'           => 'integer',
 				'single'         => true,
 				'show_in_rest'   => true,
 			]
@@ -380,7 +378,7 @@ class Post_Type {
 	/**
 	 * Admin page post meta query.
 	 *
-	 * @param array $args    Filter args.
+	 * @param array  $args    Filter args.
 	 * @param object $request Filter request.
 	 *
 	 * @return array
@@ -392,22 +390,5 @@ class Post_Type {
 			$args['meta_value'] = $request->get_param( 'metaValue' );
 		}
 		return $args;
-	}
-
-	/**
-	 * Add default value to sub menu meta.
-	 *
-	 * @param integer $post_id Filter args.
-	 * @param object  $post    Filter request.
-	 */
-	public function add_default_sub_menu_meta_to_post( int $post_id, $post ) {
-		if ( $post->post_type !== $this->slug ) {
-			return;
-		}
-
-		$value = get_post_meta( $post_id, $this->sub_menu_key, true );
-		if ( 0 === $value ) {
-			update_post_meta( $post_id, $this->sub_menu_key, 0 );
-		}
 	}
 }

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -60,7 +60,6 @@ class Post_Type {
 		add_action( 'admin_init', [ $this, 'dequeue_block_styles' ], 99 );
 		add_action( 'admin_init', [ $this, 'dequeue_editor_styles' ], 99 );
 		add_action( 'admin_init', [ $this, 'add_editor_color_palette' ], 100 );
-		add_filter( 'rest_admin-page_query', [ $this, 'admin_page_sub_menu_query' ], 10, 2 );
 		add_action( 'rest_api_init', [ $this, 'register_custom_routes' ], 999 );
 	}
 
@@ -373,22 +372,5 @@ class Post_Type {
 				],
 			]
 		);
-	}
-
-	/**
-	 * Admin page post meta query.
-	 *
-	 * @param array  $args    Filter args.
-	 * @param object $request Filter request.
-	 *
-	 * @return array
-	 */
-	public function admin_page_sub_menu_query( array $args, $request ): array {
-		$meta_key = $request->get_param( 'metaKey' );
-		if ( $meta_key ) {
-			$args['meta_key']   = $meta_key;
-			$args['meta_value'] = $request->get_param( 'metaValue' );
-		}
-		return $args;
 	}
 }

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -37,7 +37,7 @@ class Post_Type {
 	 *
 	 * @var string
 	 */
-	public $menu_parent_key = 'menu_parent';
+	public $parent_menu_key = 'parent_menu';
 
 	/**
 	 * Plugin constructor.
@@ -62,6 +62,32 @@ class Post_Type {
 		add_action( 'admin_init', [ $this, 'add_editor_color_palette' ], 100 );
 		add_action( 'save_post', [ $this, 'add_default_sub_menu_meta_to_post' ], 10, 2 );
 		add_filter( 'rest_admin-page_query', [ $this, 'admin_page_sub_menu_query' ], 10, 2 );
+		add_action( 'rest_api_init', [ $this, 'register_custom_routes' ], 999 );
+	}
+
+	/**
+	 * Register custom routes.
+	 */
+	public function register_custom_routes() {
+		register_rest_route(
+			'hello-admin/v1',
+			'/menus',
+			[
+				'methods'  => 'GET',
+				'callback' => [ $this, 'return_all_registered_menus' ],
+			]
+		);
+	}
+
+	/**
+	 * Return all registered parent manus
+	 *
+	 * @return string|null All menues in json foorm.
+	 */
+	public function return_all_registered_menus() {
+		global $menu;
+
+		return wp_json_encode( $menu );
 	}
 
 	/**
@@ -121,7 +147,7 @@ class Post_Type {
 
 		register_meta(
 			'post',
-			'menu_parent',
+			'parent_menu',
 			[
 				'object_subtype' => $this->slug,
 				'type'           => 'integer',

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -82,12 +82,11 @@ class Post_Type {
 	/**
 	 * Return all registered parent manus
 	 *
-	 * @return string|null All menues in json foorm.
+	 * @return string All menus as JSON.
 	 */
-	public function return_all_registered_menus() {
-		global $menu;
-
-		return wp_json_encode( $menu );
+	public function return_all_registered_menus(): ?string {
+		$menu = (array) get_transient( hello_admin()->admin_menu::MENU_OPTION_KEY );
+		return wp_send_json_success( $menu );
 	}
 
 	/**
@@ -381,11 +380,12 @@ class Post_Type {
 	/**
 	 * Admin page post meta query.
 	 *
-	 * @param array  $args    filter args.
-	 * @param object $request filter request.
-	 * @return $args
+	 * @param array $args    Filter args.
+	 * @param object $request Filter request.
+	 *
+	 * @return array
 	 */
-	public function admin_page_sub_menu_query( $args, $request ) {
+	public function admin_page_sub_menu_query( array $args, $request ): array {
 		$meta_key = $request->get_param( 'metaKey' );
 		if ( $meta_key ) {
 			$args['meta_key']   = $meta_key;
@@ -397,10 +397,10 @@ class Post_Type {
 	/**
 	 * Add default value to sub menu meta.
 	 *
-	 * @param integer $post_id  filter args.
-	 * @param object  $post     filter request.
+	 * @param integer $post_id Filter args.
+	 * @param object  $post    Filter request.
 	 */
-	public function add_default_sub_menu_meta_to_post( $post_id, $post ) {
+	public function add_default_sub_menu_meta_to_post( int $post_id, $post ) {
 		if ( $post->post_type !== $this->slug ) {
 			return;
 		}


### PR DESCRIPTION
Resolves #1 

Every part of this process was actually very tricky for me. First I had to figure out how to use withSelect, withDispatch and registerPlugin correctly and figure out a new structure. Once that was done, I had trouble querying parent menu pages and then adding sub menus in the correct order. I have had to use some trickery to add default custom post meta to the post as it is saved so we can use the 'sub_menu' meta key to correctly filter for parent pages. I wanted to make sure that the 'Parent Menu' selector was not showing the current post as well as any post that was already set as a sub menu.

It is all working now but you might find some of the stuff I have done quite strange. It was all very new so will be interesting to get your thoughts on everything.