### PR TITLE
Disable fullscreen mode

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -1,9 +1,41 @@
-wp.domReady( () => {
-	const { removeEditorPanel } = wp.data.dispatch( 'core/edit-post' );
-	removeEditorPanel( 'post-status' );
+/**
+ * Remember the default Fullscreen feature setting, so we can restore it when this page unloads.
+ */
+let fullscreenDefault = false;
 
+wp.domReady( () => {
+	removeEditorPanel();
+	disableFullscreenMode();
+} );
+
+window.onbeforeunload = () => {
+	restoreDefaultFullscreenMode();
+};
+
+/**
+ * Disable the "Status & visibility" section in the inspector.
+ */
+const removeEditorPanel = () => {
+	wp.data.dispatch( 'core/edit-post' ).removeEditorPanel( 'post-status' );
+};
+
+/**
+ * Disable the Fullscreen feature.
+ */
+const disableFullscreenMode = () => {
 	const isFullscreenMode = wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' );
+	fullscreenDefault = isFullscreenMode;
 	if ( isFullscreenMode ) {
 		wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' );
 	};
-} );
+};
+
+/**
+ * Restore the default Fullscreen feature setting.
+ */
+const restoreDefaultFullscreenMode = () => {
+	const isFullscreenMode = wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' );
+	if ( fullscreenDefault !== isFullscreenMode ) {
+		wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' );
+	}
+};

--- a/js/filters.js
+++ b/js/filters.js
@@ -1,5 +1,9 @@
 wp.domReady( () => {
 	const { removeEditorPanel } = wp.data.dispatch( 'core/edit-post' );
-
 	removeEditorPanel( 'post-status' );
+
+	const isFullscreenMode = wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' );
+	if ( isFullscreenMode ) {
+		wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'fullscreenMode' );
+	};
 } );


### PR DESCRIPTION
The `window.onbeforeunload` isn't ideal… I imagine it wouldn't run in a few situations. But I figured it was an okay stand-in for now. We could refactor it later by storing an option somewhere or something like that.