### PR TITLE
Add select control to assign user roles. 

### DIFF
--- a/css/editor.scss
+++ b/css/editor.scss
@@ -118,4 +118,14 @@
 .hello-admin-select-multiple select[multiple] {  
 	height: auto !important;
 	padding: 8px;
-} 
+}
+
+#hello-admin-user-roles {
+	.components-checkbox-control {
+		margin-bottom: 12px;
+	}
+}
+
+.hello-admin-user-roles-label {
+	padding-top: 15px;
+}

--- a/css/editor.scss
+++ b/css/editor.scss
@@ -114,3 +114,8 @@
 		font-size:13px
 	}
 }
+
+.hello-admin-select-multiple select[multiple] {  
+	height: auto !important;
+	padding: 8px;
+} 

--- a/js/components/admin-page-settings.js
+++ b/js/components/admin-page-settings.js
@@ -65,6 +65,24 @@ const AdminPageSettings = function() {
 				/>
 			</PanelRow>
 			<PanelRow>
+				<div className="hello-admin-select-multiple">
+					<MetaSelectControl
+						label={ __( 'User Roles', 'hello-admin' ) }
+						metaKey="user_roles"
+						help="Choose which user roles should see this admin page"
+						multiple={ true }
+						options={ [
+							{ value: null, label: __( 'Select User Roles', 'hello-admin' ), disabled: true },
+							{ value: 'administrator', label: __( 'Administrator', 'hello-admin' ) },
+							{ value: 'editor', label: __( 'Editor', 'hello-admin' ) },
+							{ value: 'author', label: __( 'Author', 'hello-admin' ) },
+							{ value: 'contributor', label: __( 'Contributor', 'hello-admin' ) },
+							{ value: 'subscriber', label: __( 'Subscriber', 'hello-admin' ) },
+						] }
+					/>
+				</div>
+			</PanelRow>
+			<PanelRow>
 				<MetaToggleControl
 					label={ __( 'Sub-Menu', 'hello-admin' ) }
 					metaKey="sub_menu"

--- a/js/components/index.js
+++ b/js/components/index.js
@@ -1,3 +1,4 @@
 export { default as MetaTextControl } from './meta-text-control';
 export { default as MetaSelectControl } from './meta-select-control';
 export { default as MetaToggleControl } from './meta-toggle-control';
+export { default as MetaCheckboxControl } from './meta-checkbox-control';

--- a/js/components/meta-checkbox-control.js
+++ b/js/components/meta-checkbox-control.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies.
+ */
+const { CheckboxControl } = wp.components;
+const { useSelect, useDispatch } = wp.data;
+
+const MetaCheckboxControl = ( function( props ) {
+	const { postMeta } = useSelect( ( select ) => {
+		return {
+			postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+		};
+	} );
+
+	const { editPost } = useDispatch( 'core/editor', [ props.metaKey ] );
+
+	const hasRole = ( role, selectedRoles ) => {
+		return selectedRoles.includes( role );
+	};
+
+	const updateRoles = ( selected, value ) => {
+		let roles = postMeta[ props.metaKey ];
+		if ( selected ) {
+			if ( roles.includes( value ) ) {
+				return;
+			}
+			roles.push( value );
+			editPost( { meta: { [ props.metaKey ]: roles } } );
+		} else {
+			roles = roles.filter( ( role ) => role !== value );
+			editPost( { meta: { [ props.metaKey ]: roles } } );
+		}
+	};
+
+	if ( ! props.options ) {
+		return <></>;
+	}
+
+	return (
+		props.options.map( ( option ) => (
+			<CheckboxControl
+				key={ option.value }
+				label={ option.label }
+				checked={ hasRole( option.value, postMeta[ props.metaKey ] ) }
+				onChange={ ( selected ) => updateRoles( selected, option.value ) }
+			/>
+		) )
+
+	);
+} );
+
+export default MetaCheckboxControl;

--- a/js/components/meta-select-control.js
+++ b/js/components/meta-select-control.js
@@ -19,6 +19,8 @@ const MetaSelectControl = ( function( props ) {
 			label={ props.label }
 			value={ postMeta[ props.metaKey ] }
 			onChange={ ( value ) => editPost( { meta: { [ props.metaKey ]: value } } ) }
+			multiple={ props.multiple ?? false }
+			help={ props.help ?? false }
 		/>
 	);
 } );

--- a/php/class-admin-menu.php
+++ b/php/class-admin-menu.php
@@ -61,6 +61,19 @@ class Admin_Menu {
 
 		while ( $admin_pages_query->have_posts() ) {
 			$admin_pages_query->the_post();
+
+			$user = wp_get_current_user();
+
+			$allowed_roles = get_post_meta(
+				get_the_ID(),
+				hello_admin()->post_type->user_roles_key,
+				true
+			);
+
+			if ( '' !== $allowed_roles && ! array_intersect( $allowed_roles, $user->roles ) ) {
+				continue;
+			}
+
 			$menu_position = (int) get_post_meta(
 				get_the_ID(),
 				hello_admin()->post_type->menu_position_key,

--- a/php/class-admin-menu.php
+++ b/php/class-admin-menu.php
@@ -26,6 +26,13 @@ class Admin_Menu {
 	const MENU_OPTION_KEY = 'hello-admin-all-menu-items';
 
 	/**
+	 * The option key used to save all menu items into a transient.
+	 *
+	 * @var string
+	 */
+	const USER_ROLES_OPTION_KEY = 'hello-admin-all-user-roles';
+
+	/**
 	 * Plugin constructor.
 	 */
 	public function __construct() {
@@ -41,6 +48,7 @@ class Admin_Menu {
 		add_action( 'admin_menu', [ $this, 'register_menu_items' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		add_action( 'admin_menu', [ $this, 'save_all_menu_items' ], 99 );
+		add_action( 'admin_menu', [ $this, 'save_all_user_roles' ], 99 );
 	}
 
 	/**
@@ -137,6 +145,14 @@ class Admin_Menu {
 	public function save_all_menu_items() {
 		global $menu;
 		set_transient( self::MENU_OPTION_KEY, $menu );
+	}
+
+	/**
+	 * Add all registered user roles to transient.
+	 */
+	public function save_all_user_roles() {
+		$user_roles = get_editable_roles();
+		set_transient( self::USER_ROLES_OPTION_KEY, $user_roles );
 	}
 
 	/**

--- a/php/class-post-type.php
+++ b/php/class-post-type.php
@@ -83,6 +83,15 @@ class Post_Type {
 				'callback' => [ $this, 'return_all_registered_menus' ],
 			]
 		);
+
+		register_rest_route(
+			'hello-admin/v1',
+			'/user-roles',
+			[
+				'methods'  => 'GET',
+				'callback' => [ $this, 'get_registed_user_roles' ],
+			]
+		);
 	}
 
 	/**
@@ -93,6 +102,16 @@ class Post_Type {
 	public function return_all_registered_menus(): ?string {
 		$menu = (array) get_transient( hello_admin()->admin_menu::MENU_OPTION_KEY );
 		return wp_send_json_success( $menu );
+	}
+
+	/**
+	 * Return all registered users roles
+	 *
+	 * @return string All user roles as JSON.
+	 */
+	public function get_registed_user_roles(): ?string {
+		$user_roles = (array) get_transient( hello_admin()->admin_menu::USER_ROLES_OPTION_KEY );
+		return wp_send_json_success( $user_roles );
 	}
 
 	/**


### PR DESCRIPTION
Resolves #4 

This PR is to replace #7 which was a mess after the last merge.

I have added in the methods to select specific user roles. If you select none at the start, it will not be hidden for any user roles. However, if you initially set a user role and then unselect all of them, it breaks and will not show for any user roles until you select new ones. Not sure the best way to handle this? If you unselect all roles, it returns an empty array, so I can possible add in another conditional check for this.

Note, I had to add back the method to add a default value of zero to sub_menu meta when the post is saved. I thought I had tested this, but I think i had a problem with npm run dev not updating automatically when the page was saved. Without this method, the query to find all admin-page posts fails as it specifically looks for the sub_menu meta in order to add parent menus first.